### PR TITLE
chore(deps): update helm release ingress-nginx to v4.11.2

### DIFF
--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   name: keda
   condition: autoscaling.enabled, keda.enabled
 - repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.11.1
+  version: 4.11.2
   name: ingress-nginx
   condition: ingress.enabled, ingress-nginx.enabled
 - repository: https://jaegertracing.github.io/helm-charts


### PR DESCRIPTION
### Description

In this pull request, the version of the `ingress-nginx` dependency in the `charts/selenium-grid/Chart.yaml` file is being updated from 4.11.1 to 4.11.2. This update could include bug fixes, security patches, or new features provided in the newer version of the dependency.

Changes:
- Update `ingress-nginx` dependency version from 4.11.1 to 4.11.2 in `charts/selenium-grid/Chart.yaml` file.